### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     java
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "8.1.1" apply false
-    id("io.papermc.paperweight.patcher") version "1.5.7-SNAPSHOT"
+    id("io.papermc.paperweight.patcher") version "1.5.7"
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group = org.purpurmc.purpur
 version = 1.20.2-R0.1-SNAPSHOT
 
 mcVersion = 1.20.2
-paperCommit = cfe311d7a51eeb9e14c526f57efab9837f30c5d0
+paperCommit = 29a02095754a8bc76f996f53e1da1cc04b5fd167
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/patches/server/0177-Make-lightning-rod-range-configurable.patch
+++ b/patches/server/0177-Make-lightning-rod-range-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make lightning rod range configurable
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index cf14ddbe97dd16972dc2830a722f7ac23b1badd0..f377eff47cc12e7e7b0b237860b330dd28b6603d 100644
+index 891ce72b7596bb81bda982c5c48148c0b565bc95..9ae770ef03d31d1ffefd7181d9bbf2d861a7f2a0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1153,7 +1153,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1154,7 +1154,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              return holder.is(PoiTypes.LIGHTNING_ROD);
          }, (blockposition1) -> {
              return blockposition1.getY() == this.getHeight(Heightmap.Types.WORLD_SURFACE, blockposition1.getX(), blockposition1.getZ()) - 1;

--- a/patches/server/0190-Customizable-sleeping-actionbar-messages.patch
+++ b/patches/server/0190-Customizable-sleeping-actionbar-messages.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Customizable sleeping actionbar messages
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f377eff47cc12e7e7b0b237860b330dd28b6603d..d0806e5bd4db7a1c0f70aeb8b694d641c64be766 100644
+index 9ae770ef03d31d1ffefd7181d9bbf2d861a7f2a0..7b6acf4e2b2ec4964fbb296f1e66f2a86faba426 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1202,11 +1202,27 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1203,11 +1203,27 @@ public class ServerLevel extends Level implements WorldGenLevel {
          if (this.canSleepThroughNights()) {
              if (!this.getServer().isSingleplayer() || this.getServer().isPublished()) {
                  int i = this.getGameRules().getInt(GameRules.RULE_PLAYERS_SLEEPING_PERCENTAGE);

--- a/patches/server/0209-Option-for-if-rain-and-thunder-should-stop-on-sleep.patch
+++ b/patches/server/0209-Option-for-if-rain-and-thunder-should-stop-on-sleep.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for if rain and thunder should stop on sleep
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d0806e5bd4db7a1c0f70aeb8b694d641c64be766..eed1384d006ff167826684d59d36bafa1f617867 100644
+index 7b6acf4e2b2ec4964fbb296f1e66f2a86faba426..fc5444f5ae0f293266548bb30f9861da9f25d265 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1361,6 +1361,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1362,6 +1362,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      private void resetWeatherCycle() {
          // CraftBukkit start
@@ -16,7 +16,7 @@ index d0806e5bd4db7a1c0f70aeb8b694d641c64be766..eed1384d006ff167826684d59d36bafa
          this.serverLevelData.setRaining(false, org.bukkit.event.weather.WeatherChangeEvent.Cause.SLEEP); // Paper - when passing the night
          // If we stop due to everyone sleeping we should reset the weather duration to some other random value.
          // Not that everyone ever manages to get the whole server to sleep at the same time....
-@@ -1368,6 +1369,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1369,6 +1370,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              this.serverLevelData.setRainTime(0);
          }
          // CraftBukkit end

--- a/patches/server/0237-Allow-void-trading.patch
+++ b/patches/server/0237-Allow-void-trading.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow void trading
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 6f39e4bdafb41c3ea0ed21eb35dcfdf78c0c7ba1..7a1e26d3aa650d24687a1bbf07e9d85c94b85712 100644
+index fc5444f5ae0f293266548bb30f9861da9f25d265..158e690713204ad2d0b6ff3d0daa1f13a8100f1e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2861,7 +2861,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2862,7 +2862,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot Start
              if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder && (!(entity instanceof ServerPlayer) || entity.getRemovalReason() != Entity.RemovalReason.KILLED)) { // SPIGOT-6876: closeInventory clears death message
                  // Paper start

--- a/patches/server/0265-Remove-Timings.patch
+++ b/patches/server/0265-Remove-Timings.patch
@@ -427,7 +427,7 @@ index 17b6925b46f8386dcfc561483693de516465ec12..9dc3dec2bdf2e503fe10364dd4bb5cf6
              gameprofilerfiller.pop();
              gameprofilerfiller.pop();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343ddac77dc6d 100644
+index 158e690713204ad2d0b6ff3d0daa1f13a8100f1e..b1f5ccd309f84f7b53d16ad6241bb4cb1bdd0726 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -856,7 +856,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -514,7 +514,7 @@ index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343dd
          gameprofilerfiller.pop();
      }
  
-@@ -1437,8 +1437,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1438,8 +1438,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
          // Spigot end
          // Paper start- timings
          final boolean isActive = org.spigotmc.ActivationRange.checkIfActive(entity);
@@ -525,7 +525,7 @@ index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343dd
          // Paper end - timings
          entity.setOldPosAndRot();
          ProfilerFiller gameprofilerfiller = this.getProfiler();
-@@ -1454,7 +1454,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1455,7 +1455,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          entity.postTick(); // CraftBukkit
          } else { entity.inactiveTick(); } // Paper - EAR 2
          this.getProfiler().pop();
@@ -534,7 +534,7 @@ index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343dd
          Iterator iterator = entity.getPassengers().iterator();
  
          while (iterator.hasNext()) {
-@@ -1477,8 +1477,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1478,8 +1478,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
              if (passenger instanceof Player || this.entityTickList.contains(passenger)) {
                  // Paper - EAR 2
                  final boolean isActive = org.spigotmc.ActivationRange.checkIfActive(passenger);
@@ -545,7 +545,7 @@ index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343dd
                  // Paper end
                  passenger.setOldPosAndRot();
                  ++passenger.tickCount;
-@@ -1508,7 +1508,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1509,7 +1509,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                      this.tickPassenger(passenger, entity2);
                  }
  
@@ -554,7 +554,7 @@ index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343dd
              }
          } else {
              passenger.stopRiding();
-@@ -1528,14 +1528,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1529,14 +1529,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(getWorld()));
          }
  
@@ -572,7 +572,7 @@ index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343dd
  
              // Copied from save()
              // CraftBukkit start - moved from MinecraftServer.saveChunks
-@@ -1547,7 +1547,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1548,7 +1548,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  this.convertable.saveDataTag(this.server.registryAccess(), this.serverLevelData, this.server.getPlayerList().getSingleplayerData());
              }
              // CraftBukkit end
@@ -581,7 +581,7 @@ index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343dd
      }
      // Paper end
  
-@@ -1561,7 +1561,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1562,7 +1562,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          if (!savingDisabled) {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(getWorld())); // CraftBukkit
@@ -590,7 +590,7 @@ index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343dd
              if (progressListener != null) {
                  progressListener.progressStartNoAbort(Component.translatable("menu.savingLevel"));
              }
-@@ -1571,11 +1571,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1572,11 +1572,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  progressListener.progressStage(Component.translatable("menu.savingChunks"));
              }
  
@@ -606,7 +606,7 @@ index ff9adf5d04ad08342eeca166bd582774bf6f2cdd..1688fdea27342783f91b5cd0a09343dd
  
          } else if (close) { chunkproviderserver.close(false); } // Paper - rewrite chunk system
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 87e064670d336f1c3a86cdc524e2686c7ee5af72..9fa25455dd264ea0b58d5e1825fd88475021dea9 100644
+index d5f4e95fe5d796c419e5b76042dda638c26d15ed..d01116aa7b547e5020b69df36cdf035af2cae882 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2446,7 +2446,7 @@ public class ServerGamePacketListenerImpl extends ServerCommonPacketListenerImpl

--- a/patches/server/0266-Remove-Mojang-Profiler.patch
+++ b/patches/server/0266-Remove-Mojang-Profiler.patch
@@ -564,7 +564,7 @@ index 9dc3dec2bdf2e503fe10364dd4bb5cf662288260..4ab448842dcbf7f0f45d4443d0bb007e
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 613f1ca115441f6a90830e7be8262493105ddf2f..ef654df11d946cb9560fa05dae86ba727832106e 100644
+index b1f5ccd309f84f7b53d16ad6241bb4cb1bdd0726..db3c7b914a301005ba7fa92c7c042777b2fbda72 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -823,12 +823,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -718,7 +718,7 @@ index 613f1ca115441f6a90830e7be8262493105ddf2f..ef654df11d946cb9560fa05dae86ba72
      }
  
      private void tickIceAndSnow(boolean raining, BlockPos.MutableBlockPos blockposition1, final LevelChunk chunk) { // Paper - optimise chunk ticking
-@@ -1441,19 +1440,19 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1442,19 +1441,19 @@ public class ServerLevel extends Level implements WorldGenLevel {
          //try { // Purpur
          // Paper end - timings
          entity.setOldPosAndRot();
@@ -743,7 +743,7 @@ index 613f1ca115441f6a90830e7be8262493105ddf2f..ef654df11d946cb9560fa05dae86ba72
          //} finally { timer.stopTiming(); } // Paper - timings // Purpur
          Iterator iterator = entity.getPassengers().iterator();
  
-@@ -1482,12 +1481,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1483,12 +1482,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  // Paper end
                  passenger.setOldPosAndRot();
                  ++passenger.tickCount;
@@ -760,7 +760,7 @@ index 613f1ca115441f6a90830e7be8262493105ddf2f..ef654df11d946cb9560fa05dae86ba72
                  // Paper start - EAR 2
                  if (isActive) {
                  passenger.rideTick();
-@@ -1499,7 +1498,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1500,7 +1499,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                      vehicle.positionRider(passenger);
                  }
                  // Paper end - EAR 2
@@ -1155,7 +1155,7 @@ index 28cac00d496cc6e37648dbe96ba4aea2b834cedd..6e0331818ef68fa355e3c27dc3e362b8
              }
          } else {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9ca3a8df8d4e0cd733c489c930b563888fb01ffa..a9b87083623050cf9b0a5311f0f687e0ada73137 100644
+index 3788737aceca571827c958623c1b241e24917f6e..c132ab8142bf55f2ab00617b7ba90c610016ae7d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -411,7 +411,7 @@ public abstract class LivingEntity extends Entity implements Attackable {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@08c0b48 [ci skip] update paperweight to 1.5.7 & re-enable filterpatches (#9799) PaperMC/Paper@29a0209 Properly check water block when random ticking ice (#9804)