### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,3 +32,6 @@ ij_java_generate_final_parameters = true
 
 [test-plugin/**/*.java]
 ij_java_use_fq_class_names = false
+
+[Purpur-Server/src/main/resources/data/**/*.json]
+indent_size = 2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     java
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "8.1.1" apply false
-    id("io.papermc.paperweight.patcher") version "1.5.7"
+    id("io.papermc.paperweight.patcher") version "1.5.8"
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group = org.purpurmc.purpur
 version = 1.20.2-R0.1-SNAPSHOT
 
 mcVersion = 1.20.2
-paperCommit = a702a083cdab79992a0117fecd3bc64d7d61f7fe
+paperCommit = 2f5bb7e30630532328ed1b051e8ef1912eae7cf1
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/patches/server/0001-Rebrand.patch
+++ b/patches/server/0001-Rebrand.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Rebrand
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 683159586641dd9aa42ae96fa51602469755723f..ffee77918e7390c810010e057d088c2967d1e7b0 100644
+index c187641f0ec6444a10e0e1583e1697d07e8f0267..9511ffbc88a374c4c7945da79af42433fd532d8c 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -13,8 +13,12 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
@@ -197,7 +197,7 @@ index 97745f0bab8d82d397c6c2a5775aed92bca0a034..707a02804db563d94360b65d156c40be
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fcd5096d64edfaf6bce3ecce8c9b9afb84462786..00997982aa478aba822b288f4f18779d8dbcf3cc 100644
+index b7e7e6ed60f55d2ab5e4fcefb3638ad1768c3b7f..d69b765678f94eacf171841be47a8ff4f37fd405 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -267,7 +267,7 @@ import javax.annotation.Nullable; // Paper
@@ -263,10 +263,10 @@ index d7ce4971d9271dbeff4adb9d852e4e7bdf60bf03..5a47a8785bc2e251d041f80a79295c43
                  // (async tasks must live with race-conditions if they attempt to cancel between these few lines of code)
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 96f6e0554baf5915dd1f5b93f3bcfe7a13393c29..17c09c532838aeeb014b6884b6907151f6c82d13 100644
+index 806fb1064a1769d1251f2a2b04372275754d2aeb..717b1f797d28129a0f5c7c9c7b01691aa4f14317 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -452,7 +452,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -462,7 +462,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      @Override
      public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {

--- a/patches/server/0006-Ridables.patch
+++ b/patches/server/0006-Ridables.patch
@@ -5181,10 +5181,10 @@ index 06d1bdb9bd124b201c36d284c50d22bf50d3735a..937f57d8af629c4e913d7ccabf6adab1
      public boolean isPickable() {
          return false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 315d8260e196709ed9084272aa640f11e327c0a8..25883decef819df7758b8fdd7c4de48f0d0d05a1 100644
+index f7ebddd35ff5a60a81034fd7de035ebba83e9517..6092004f91e1a4a143df1a82bcad9c16760f5096 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1523,4 +1523,27 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1527,4 +1527,27 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().getScoreboardName();
      }
      // Paper end - entity scoreboard name


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@99b735c Make EntityLookup#get use read lock for entity maps PaperMC/Paper@a2ba452 Update paperweight to 1.5.8 (#9814) PaperMC/Paper@e87240b Fixes for loot tables (#9818) PaperMC/Paper@72f7945 Fix painting loosing art on face change (#9798) PaperMC/Paper@69ce927 Make setVelocity method of Fireballs change the travel direction to an arbitrary vector (#9815) PaperMC/Paper@7e5dd92 fix flat bedrock world config (#9728) PaperMC/Paper@5509610 Fix UnsafeValues#loadAdvancement (#9753) PaperMC/Paper@1a4778d Fix PlayerSwapHandItemsEvent NPE when a hand set to null (#9763) PaperMC/Paper@2f5bb7e add predicate recipe choice only for potion mixes (#9486)