### PR TITLE
Updated Upstream (Paper/Purpur)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group = org.purpurmc.purpur
 version = 1.20.2-R0.1-SNAPSHOT
 
 mcVersion = 1.20.2
-paperCommit = 4b0bc74c90582f2d52d720c795228130545cd103
+paperCommit = 71a1787f6cf34347a8a8e50d9834906ef0edcb27
 
 org.gradle.caching = true
 org.gradle.parallel = true


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@a3e4d1a Don't check if we can see non-visible entities PaperMC/Paper@3a5c6f8 Fix NPE in SculkBloomEvent world access (#9857) PaperMC/Paper@71a1787 [ci skip] cleanup some ATs (#9840)