### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group = org.purpurmc.purpur
 version = 1.20.2-R0.1-SNAPSHOT
 
 mcVersion = 1.20.2
-paperCommit = 71a1787f6cf34347a8a8e50d9834906ef0edcb27
+paperCommit = c1ac98328c3b4dc2834497aae70020af7b3c7d04
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/patches/api/0041-Add-local-difficulty-api.patch
+++ b/patches/api/0041-Add-local-difficulty-api.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add local difficulty api
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 8d861f5522a33669f67b3e41dfbc5234637114b4..d12443e6e1f71354dcfab9cf2f166a1097b589b5 100644
+index 91eb95b04094394e8dc1e3a3343efc63690c87e4..381cd0296ece416876e136d2ca710c18c3e8bea0 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -4010,6 +4010,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -4072,6 +4072,16 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public DragonBattle getEnderDragonBattle();
  

--- a/patches/api/0044-Debug-Marker-API.patch
+++ b/patches/api/0044-Debug-Marker-API.patch
@@ -179,10 +179,10 @@ index 3bc9fa8b68b284516ddbf0ace0c1dc52768307cb..aaef58468a3c31f35e5067ed4263e9dd
      // Purpur end
  }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index d12443e6e1f71354dcfab9cf2f166a1097b589b5..9a1526d3da2052815404328c2022119b98db7aa4 100644
+index 381cd0296ece416876e136d2ca710c18c3e8bea0..d8ef44761148f928a671ceba74a5d1cb87af81d9 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -4018,6 +4018,76 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -4080,6 +4080,76 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
       * @return The local difficulty
       */
      public float getLocalDifficultyAt(@NotNull Location location);

--- a/patches/server/0001-Pufferfish-Server-Changes.patch
+++ b/patches/server/0001-Pufferfish-Server-Changes.patch
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a79461457ea19339f47572c70705d655ebc55276..57739f9dd7d045d1a585a9fc1be290a1a007db6a 100644
+index 79beac737c17412913983614bd478d33e3c6ed58..f2d26ccc6abbe7804789117b0659f8094899cc33 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -13,8 +13,12 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
@@ -38,7 +38,7 @@ index a79461457ea19339f47572c70705d655ebc55276..57739f9dd7d045d1a585a9fc1be290a1
      // Paper start
      implementation("org.jline:jline-terminal-jansi:3.21.0")
      implementation("net.minecrell:terminalconsoleappender:1.3.0")
-@@ -52,12 +56,27 @@ dependencies {
+@@ -51,6 +55,13 @@ dependencies {
      runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.3")
      runtimeOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.3")
  
@@ -52,6 +52,7 @@ index a79461457ea19339f47572c70705d655ebc55276..57739f9dd7d045d1a585a9fc1be290a1
      testImplementation("io.github.classgraph:classgraph:4.8.47") // Paper - mob goal test
      testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
      testImplementation("org.hamcrest:hamcrest:2.2")
+@@ -58,6 +69,14 @@ dependencies {
  }
  
  val craftbukkitPackageVersion = "1_20_R2" // Paper
@@ -1527,7 +1528,7 @@ index dbccbcb9b44e4efacdf53c2d161115cc20b36cff..66aeb0ea388a8c8a08cf33728921061a
          }
      }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 0c2617574e21037d94ac56ad08b490f9bca5c5af..7eaee0d0dcbb420abb5c49ba0a465d90fe513551 100644
+index 28c6ec04750daca3d77a0cee2b9f17f2508662cc..261145fced66b677e8f4159b71b4a16638c57da2 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -206,7 +206,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -3305,10 +3306,10 @@ index acfe2676b840d4edc70507aa139f7db212ed90b7..ef89684b5e8ab20744ba02a71fe0465d
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 806fb1064a1769d1251f2a2b04372275754d2aeb..3298aac109e08da4801a6f08aa6f7acfc5e6bf16 100644
+index 6b31f88803041c75023a2c99bdc1efd902f0205c..2ce2bf42dd6363b7f4325fb0387c61b5deff9ced 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -462,7 +462,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -475,7 +475,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      @Override
      public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {

--- a/patches/server/0003-Rebrand.patch
+++ b/patches/server/0003-Rebrand.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Rebrand
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f8b27b3992f1d59bf0e95bba0961540e88345754..e372110a189857056e4fae3cd1d996ce8cb69493 100644
+index 6dd0015c4a8afb9cd36e79f5745f0afd63c6e524..0eeca0c0dfbb62b7551cda95576932d3f14e6de2 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -13,12 +13,12 @@ configurations.named(log4jPlugins.compileClasspathConfigurationName) {
@@ -25,7 +25,7 @@ index f8b27b3992f1d59bf0e95bba0961540e88345754..e372110a189857056e4fae3cd1d996ce
      // Paper start
      implementation("org.jline:jline-terminal-jansi:3.21.0")
      implementation("net.minecrell:terminalconsoleappender:1.3.0")
-@@ -63,6 +63,10 @@ dependencies {
+@@ -62,6 +62,10 @@ dependencies {
      }
      // Pufferfish end
  
@@ -265,10 +265,10 @@ index d7ce4971d9271dbeff4adb9d852e4e7bdf60bf03..5a47a8785bc2e251d041f80a79295c43
                  // (async tasks must live with race-conditions if they attempt to cancel between these few lines of code)
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 3298aac109e08da4801a6f08aa6f7acfc5e6bf16..33ea5172bb7fe1018bc39acc16963f4998ac52b2 100644
+index 2ce2bf42dd6363b7f4325fb0387c61b5deff9ced..61f3f9550f0e2e62515502ccc5e7b90178a5db47 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -462,7 +462,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -475,7 +475,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      @Override
      public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {

--- a/patches/server/0061-Item-entity-immunities.patch
+++ b/patches/server/0061-Item-entity-immunities.patch
@@ -66,10 +66,10 @@ index eb0351aa12eebcefab1d1d14641fc3c60cbbcab8..4f01fede54a3150798812d6e5116631b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
-index 5e83fabb20bc2b0668cbf48530053ca1bb9092f3..8fcee0e426cd598ddfd7e12df4382d57d2016780 100644
+index 9c0f83ff8113696309265fb9e8f6006296de86a6..c57f0ae102f1c9833ed7f93af4682caf490ec70c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
-@@ -154,4 +154,46 @@ public class CraftItem extends CraftEntity implements Item {
+@@ -151,4 +151,46 @@ public class CraftItem extends CraftEntity implements Item {
      public String toString() {
          return "CraftItem";
      }
@@ -77,22 +77,22 @@ index 5e83fabb20bc2b0668cbf48530053ca1bb9092f3..8fcee0e426cd598ddfd7e12df4382d57
 +    // Purpur start
 +    @Override
 +    public void setImmuneToCactus(boolean immuneToCactus) {
-+        item.immuneToCactus = immuneToCactus;
++        this.getHandle().immuneToCactus = immuneToCactus;
 +    }
 +
 +    @Override
 +    public boolean isImmuneToCactus() {
-+        return item.immuneToCactus;
++        return this.getHandle().immuneToCactus;
 +    }
 +
 +    @Override
 +    public void setImmuneToExplosion(boolean immuneToExplosion) {
-+        item.immuneToExplosion = immuneToExplosion;
++        this.getHandle().immuneToExplosion = immuneToExplosion;
 +    }
 +
 +    @Override
 +    public boolean isImmuneToExplosion() {
-+        return item.immuneToExplosion;
++        return this.getHandle().immuneToExplosion;
 +    }
 +
 +    @Override
@@ -102,17 +102,17 @@ index 5e83fabb20bc2b0668cbf48530053ca1bb9092f3..8fcee0e426cd598ddfd7e12df4382d57
 +
 +    @Override
 +    public boolean isImmuneToFire() {
-+        return item.immuneToFire;
++        return this.getHandle().immuneToFire;
 +    }
 +
 +    @Override
 +    public void setImmuneToLightning(boolean immuneToLightning) {
-+        item.immuneToLightning = immuneToLightning;
++        this.getHandle().immuneToLightning = immuneToLightning;
 +    }
 +
 +    @Override
 +    public boolean isImmuneToLightning() {
-+        return item.immuneToLightning;
++        return this.getHandle().immuneToLightning;
 +    }
 +    // Purpur end
  }

--- a/patches/server/0227-Potion-NamespacedKey.patch
+++ b/patches/server/0227-Potion-NamespacedKey.patch
@@ -191,10 +191,10 @@ index 42b336a96e5c786b95356200da7d02bfd8b584dc..f79d79d7c9ca18ac711b81c8c3d94e21
          return effects;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
-index 5a71efd27180004ee91495d9255867dbdfa1783e..1dcc3405393d11836a21aa16e435be64c04f6e7d 100644
+index 677fdb8c312f79daade76f169292a2a989e11eec..e67c86bae2ab419dd4e6d989d12cef81d135cc2e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
-@@ -43,6 +43,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+@@ -45,6 +45,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
      static final ItemMetaKey POTION_COLOR = new ItemMetaKey("CustomPotionColor", "custom-color");
      static final ItemMetaKey ID = new ItemMetaKey("id", "potion-id");
      static final ItemMetaKey DEFAULT_POTION = new ItemMetaKey("Potion", "potion-type");
@@ -202,7 +202,7 @@ index 5a71efd27180004ee91495d9255867dbdfa1783e..1dcc3405393d11836a21aa16e435be64
  
      // Having an initial "state" in ItemMeta seems bit dirty but the UNCRAFTABLE potion type
      // is treated as the empty form of the meta because it represents an empty potion with no effect
-@@ -92,7 +93,13 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+@@ -97,7 +98,13 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
                  boolean ambient = effect.getBoolean(AMBIENT.NBT);
                  boolean particles = effect.contains(SHOW_PARTICLES.NBT, CraftMagicNumbers.NBT.TAG_BYTE) ? effect.getBoolean(SHOW_PARTICLES.NBT) : true;
                  boolean icon = effect.contains(SHOW_ICON.NBT, CraftMagicNumbers.NBT.TAG_BYTE) ? effect.getBoolean(SHOW_ICON.NBT) : particles;
@@ -217,7 +217,7 @@ index 5a71efd27180004ee91495d9255867dbdfa1783e..1dcc3405393d11836a21aa16e435be64
              }
          }
      }
-@@ -139,6 +146,11 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+@@ -150,6 +157,11 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
                  effectData.putBoolean(AMBIENT.NBT, effect.isAmbient());
                  effectData.putBoolean(SHOW_PARTICLES.NBT, effect.hasParticles());
                  effectData.putBoolean(SHOW_ICON.NBT, effect.hasIcon());
@@ -229,7 +229,7 @@ index 5a71efd27180004ee91495d9255867dbdfa1783e..1dcc3405393d11836a21aa16e435be64
                  effectList.add(effectData);
              }
          }
-@@ -200,7 +212,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+@@ -225,7 +237,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
          if (index != -1) {
              if (overwrite) {
                  PotionEffect old = this.customEffects.get(index);
@@ -239,10 +239,10 @@ index 5a71efd27180004ee91495d9255867dbdfa1783e..1dcc3405393d11836a21aa16e435be64
                  }
                  this.customEffects.set(index, effect);
 diff --git a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
-index 354393cbf0f113f14e936b40da56125a3130cbd9..a1ef7ecdf272546bdd76bb4b2ecd86a69c51c777 100644
+index e29679a92da5ec05e122bb972a5ee469059a7a0a..70a3463eb6c93b662c5858016f934aa9ab267397 100644
 --- a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
 +++ b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
-@@ -101,7 +101,7 @@ public class CraftPotionUtil {
+@@ -73,7 +73,7 @@ public class CraftPotionUtil {
  
      public static MobEffectInstance fromBukkit(PotionEffect effect) {
          MobEffect type = CraftPotionEffectType.bukkitToMinecraft(effect.getType());
@@ -251,7 +251,7 @@ index 354393cbf0f113f14e936b40da56125a3130cbd9..a1ef7ecdf272546bdd76bb4b2ecd86a6
      }
  
      public static PotionEffect toBukkit(MobEffectInstance effect) {
-@@ -110,7 +110,7 @@ public class CraftPotionUtil {
+@@ -82,7 +82,7 @@ public class CraftPotionUtil {
          int duration = effect.getDuration();
          boolean ambient = effect.isAmbient();
          boolean particles = effect.isVisible();
@@ -261,7 +261,7 @@ index 354393cbf0f113f14e936b40da56125a3130cbd9..a1ef7ecdf272546bdd76bb4b2ecd86a6
  
      public static boolean equals(MobEffect mobEffect, PotionEffectType type) {
 diff --git a/src/test/java/org/bukkit/potion/PotionTest.java b/src/test/java/org/bukkit/potion/PotionTest.java
-index 70a655df7195da8e037c22064c4ebfe5d771e884..cfdf155af7ec29dd221989edbd8623d27529f9e6 100644
+index 8963d93e99bdaf719fa160c11dd5af6a1d86f9a4..d852d8b14f5000415cbb4f06601059b3934b7efc 100644
 --- a/src/test/java/org/bukkit/potion/PotionTest.java
 +++ b/src/test/java/org/bukkit/potion/PotionTest.java
 @@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;

--- a/patches/server/0262-Add-local-difficulty-api.patch
+++ b/patches/server/0262-Add-local-difficulty-api.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add local difficulty api
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0e670de77a7f9926e295e1dd63d909bed1a959ca..791e69b2c963cd034d6d35561448cdb20b1b1cde 100644
+index 4879b585df9a6488922511a8e6603964bd13abcf..e4cfc31970ca6ee2b1f943d9d1771c9d369effb1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2289,6 +2289,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2298,6 +2298,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (this.getHandle().getDragonFight() == null) ? null : new CraftDragonBattle(this.getHandle().getDragonFight());
      }
  

--- a/patches/server/0270-Debug-Marker-API.patch
+++ b/patches/server/0270-Debug-Marker-API.patch
@@ -52,10 +52,10 @@ index 6e8cd10ec919e9c42c214a9a9c78a51794731fb6..2b3b9be41930a73886735394e12f6e3e
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 791e69b2c963cd034d6d35561448cdb20b1b1cde..52b48e40c3ee5f483c6cb04409459cf25abc3f0d 100644
+index e4cfc31970ca6ee2b1f943d9d1771c9d369effb1..42040939ae5e1e576c59cd0e1e3bcdb51899139f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2293,6 +2293,42 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2302,6 +2302,42 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public float getLocalDifficultyAt(Location location) {
          return getHandle().getCurrentDifficultyAt(io.papermc.paper.util.MCUtil.toBlockPosition(location)).getEffectiveDifficulty();
      }

--- a/patches/server/0286-Fire-Immunity-API.patch
+++ b/patches/server/0286-Fire-Immunity-API.patch
@@ -71,16 +71,16 @@ index eb409ecf5bf06692038e9fe84af986092a7d7837..4482e9401be4af7b16991f37d319e906
      public boolean isInDaylight() {
          return getHandle().isSunBurnTick();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
-index 8fcee0e426cd598ddfd7e12df4382d57d2016780..4ffb4046b63cbc140c76721f51c9a7a09e81844d 100644
+index c57f0ae102f1c9833ed7f93af4682caf490ec70c..26d59cdc87645b775441e013bb334c1ae6b9db55 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
-@@ -176,9 +176,14 @@ public class CraftItem extends CraftEntity implements Item {
-         return item.immuneToExplosion;
+@@ -173,9 +173,14 @@ public class CraftItem extends CraftEntity implements Item {
+         return this.getHandle().immuneToExplosion;
      }
  
 +    @Override
 +    public void setImmuneToFire(@org.jetbrains.annotations.Nullable Boolean immuneToFire) {
-+        item.immuneToFire = (immuneToFire != null && immuneToFire);
++        this.getHandle().immuneToFire = (immuneToFire != null && immuneToFire);
 +    }
 +
      @Override


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@489bff9 Temp fix for serialisable blockdata PaperMC/Paper@90fe0d5 Updated Upstream (Bukkit/CraftBukkit/Spigot) (#9825) PaperMC/Paper@c1ac983 Fix log level of advancement debug message (#9860)